### PR TITLE
Distant models: handle endpoint parameters

### DIFF
--- a/tests/test_distant_http_model.py
+++ b/tests/test_distant_http_model.py
@@ -7,7 +7,11 @@ import pytest
 import requests
 
 from modelkit.core.library import ModelLibrary
-from modelkit.core.models.distant_model import AsyncDistantHTTPModel, DistantHTTPModel
+from modelkit.core.models.distant_model import (
+    AsyncDistantHTTPModel,
+    DistantHTTPModel,
+    build_url,
+)
 from tests import TEST_DIR
 
 
@@ -74,3 +78,25 @@ async def test_distant_http_model(run_mocked_service, event_loop):
     # Test with synchronous mode
     m = lib.get("some_model_sync")
     assert ITEM == m(ITEM)
+
+
+@pytest.mark.parametrize(
+    "url,params,expected",
+    [
+        ("", {}, ""),
+        ("", {"param1": "a", "param2": "b"}, "?param1=a&param2=b"),
+        ("some_url_without_params", {}, "some_url_without_params"),
+        (
+            "some_url_with_params",
+            {"param1": 10, "param2": 50},
+            "some_url_with_params?param1=10&param2=50",
+        ),
+        (
+            "some_url_with_none_params",
+            {"param1": None, "param2": None},
+            "some_url_with_none_params?param1=None&param2=None",
+        ),
+    ],
+)
+def test_build_url(url, params, expected):
+    assert build_url(url, params) == expected

--- a/tests/test_distant_http_model.py
+++ b/tests/test_distant_http_model.py
@@ -7,11 +7,7 @@ import pytest
 import requests
 
 from modelkit.core.library import ModelLibrary
-from modelkit.core.models.distant_model import (
-    AsyncDistantHTTPModel,
-    DistantHTTPModel,
-    build_url,
-)
+from modelkit.core.models.distant_model import AsyncDistantHTTPModel, DistantHTTPModel
 from tests import TEST_DIR
 
 
@@ -78,25 +74,3 @@ async def test_distant_http_model(run_mocked_service, event_loop):
     # Test with synchronous mode
     m = lib.get("some_model_sync")
     assert ITEM == m(ITEM)
-
-
-@pytest.mark.parametrize(
-    "url,params,expected",
-    [
-        ("", {}, ""),
-        ("", {"param1": "a", "param2": "b"}, "?param1=a&param2=b"),
-        ("some_url_without_params", {}, "some_url_without_params"),
-        (
-            "some_url_with_params",
-            {"param1": 10, "param2": 50},
-            "some_url_with_params?param1=10&param2=50",
-        ),
-        (
-            "some_url_with_none_params",
-            {"param1": None, "param2": None},
-            "some_url_with_none_params?param1=None&param2=None",
-        ),
-    ],
-)
-def test_build_url(url, params, expected):
-    assert build_url(url, params) == expected

--- a/tests/test_distant_http_model.py
+++ b/tests/test_distant_http_model.py
@@ -11,7 +11,7 @@ from modelkit.core.models.distant_model import AsyncDistantHTTPModel, DistantHTT
 from tests import TEST_DIR
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def run_mocked_service():
     proc = subprocess.Popen(
         ["uvicorn", "mocked_service:app"], cwd=os.path.join(TEST_DIR, "testdata")

--- a/tests/testdata/mocked_service.py
+++ b/tests/testdata/mocked_service.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 
 import fastapi
 from starlette.responses import JSONResponse
@@ -7,5 +7,13 @@ app = fastapi.FastAPI(title="Mock service")
 
 
 @app.post("/api/path/endpoint")
-async def some_endpoint(item: Dict[str, str]):
+async def some_endpoint(
+    item: Dict[str, str],
+    limit: Optional[int] = None,
+    skip: Optional[int] = None,
+):
+    if limit:
+        item["limit"] = limit
+    if skip:
+        item["skip"] = skip
     return JSONResponse(item)


### PR DESCRIPTION
This PR aims at handling endpoint parameters by distant models, parameters that should be defined at the Model's instantiation or at predict time.

Looking forward to your feedback on this.
Thanks!
