### PR TITLE
add MODELKIT_ prefix to ENABLE_SIMPLE_TRACEBACK env variable

### DIFF
--- a/modelkit/core/errors.py
+++ b/modelkit/core/errors.py
@@ -113,7 +113,7 @@ def wrap_modelkit_exceptions(func: T) -> T:
             try:
                 return func(*args, **kwargs)
             except PredictionError as exc:
-                if os.environ.get("ENABLE_SIMPLE_TRACEBACK", "True") == "True":
+                if os.environ.get("MODELKIT_ENABLE_SIMPLE_TRACEBACK", "True") == "True":
                     raise strip_modelkit_traceback_frames(exc.exc)
                 raise exc.exc
             except BaseException:
@@ -131,7 +131,7 @@ def wrap_modelkit_exceptions_gen(func: T) -> T:
             try:
                 yield from func(*args, **kwargs)
             except PredictionError as exc:
-                if os.environ.get("ENABLE_SIMPLE_TRACEBACK", "True") == "True":
+                if os.environ.get("MODELKIT_ENABLE_SIMPLE_TRACEBACK", "True") == "True":
                     raise strip_modelkit_traceback_frames(exc.exc)
                 raise exc.exc
             except BaseException:
@@ -149,7 +149,7 @@ def wrap_modelkit_exceptions_async(func: T) -> T:
             try:
                 return await func(*args, **kwargs)
             except PredictionError as exc:
-                if os.environ.get("ENABLE_SIMPLE_TRACEBACK", "True") == "True":
+                if os.environ.get("MODELKIT_ENABLE_SIMPLE_TRACEBACK", "True") == "True":
                     raise strip_modelkit_traceback_frames(exc.exc)
                 raise exc.exc
             except BaseException:
@@ -169,7 +169,7 @@ def wrap_modelkit_exceptions_gen_async(func: T) -> T:
                 async for x in func(*args, **kwargs):
                     yield x
             except PredictionError as exc:
-                if os.environ.get("ENABLE_SIMPLE_TRACEBACK", "True") == "True":
+                if os.environ.get("MODELKIT_ENABLE_SIMPLE_TRACEBACK", "True") == "True":
                     raise strip_modelkit_traceback_frames(exc.exc)
                 raise exc.exc
             except BaseException:

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -57,7 +57,7 @@ def test_prediction_error_composition():
 
 @pytest.mark.parametrize("model", [ErrorModel(), ErrorBatchModel()])
 def test_prediction_error_complex_tb(monkeypatch, model):
-    monkeypatch.setenv("ENABLE_SIMPLE_TRACEBACK", False)
+    monkeypatch.setenv("MODELKIT_ENABLE_SIMPLE_TRACEBACK", False)
     with pytest.raises(CustomError) as excinfo:
         model.predict({})
     assert len(excinfo.traceback) > 3
@@ -106,7 +106,7 @@ async def test_prediction_error_async(model):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model", [AsyncErrorModel(), AsyncErrorBatchModel()])
 async def test_prediction_error_complex_tb_async(monkeypatch, model):
-    monkeypatch.setenv("ENABLE_SIMPLE_TRACEBACK", False)
+    monkeypatch.setenv("MODELKIT_ENABLE_SIMPLE_TRACEBACK", False)
     with pytest.raises(CustomError) as excinfo:
         await model.predict({})
     assert len(excinfo.traceback) > 3


### PR DESCRIPTION
In this PR, I just add the `MODELKIT` prefix to the env variable `ENABLE_SIMPLE_TRACEBACK`.
Thanks for reviewing!