### PR TITLE
Fix model describe return type

### DIFF
--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -291,7 +291,7 @@ class AbstractModel(Asset, Generic[ItemType, ReturnType]):
             sub_t = t.add(
                 f"[deep_sky_blue1]signature[/deep_sky_blue1]: "
                 f"{pretty_print_type(self._item_type)} ->"
-                f" {pretty_print_type(self._item_type)}"
+                f" {pretty_print_type(self._return_type)}"
             )
 
         if self._load_time:

--- a/tests/testdata/api/openapi.json
+++ b/tests/testdata/api/openapi.json
@@ -63,7 +63,7 @@
   "paths": {
     "/predict/async_model": {
       "post": {
-        "description": "\n\n```                                                                                \n├── configuration: async_model                                                  \n├── signature: ItemModel -> ItemModel                                           \n```",
+        "description": "\n\n```                                                                                \n├── configuration: async_model                                                  \n├── signature: ItemModel -> ResultModel                                         \n```",
         "operationId": "_aendpoint_predict_async_model_post",
         "requestBody": {
           "content": {
@@ -103,7 +103,7 @@
     },
     "/predict/batch/async_model": {
       "post": {
-        "description": "\n\n```                                                                                \n├── configuration: async_model                                                  \n├── signature: ItemModel -> ItemModel                                           \n```",
+        "description": "\n\n```                                                                                \n├── configuration: async_model                                                  \n├── signature: ItemModel -> ResultModel                                         \n```",
         "operationId": "_aendpoint_predict_batch_async_model_post",
         "requestBody": {
           "content": {
@@ -189,7 +189,7 @@
     },
     "/predict/batch/some_complex_model": {
       "post": {
-        "description": "    With **a lot** of documentation\n\n```                                                                                \n├── configuration: some_complex_model                                           \n├── doc: More complex                                                           \n│                                                                               \n│       With **a lot** of documentation                                         \n├── signature: ItemModel -> ItemModel                                           \n```",
+        "description": "    With **a lot** of documentation\n\n```                                                                                \n├── configuration: some_complex_model                                           \n├── doc: More complex                                                           \n│                                                                               \n│       With **a lot** of documentation                                         \n├── signature: ItemModel -> ResultModel                                         \n```",
         "operationId": "_endpoint_predict_batch_some_complex_model_post",
         "requestBody": {
           "content": {
@@ -357,7 +357,7 @@
     },
     "/predict/some_complex_model": {
       "post": {
-        "description": "    With **a lot** of documentation\n\n```                                                                                \n├── configuration: some_complex_model                                           \n├── doc: More complex                                                           \n│                                                                               \n│       With **a lot** of documentation                                         \n├── signature: ItemModel -> ItemModel                                           \n```",
+        "description": "    With **a lot** of documentation\n\n```                                                                                \n├── configuration: some_complex_model                                           \n├── doc: More complex                                                           \n│                                                                               \n│       With **a lot** of documentation                                         \n├── signature: ItemModel -> ResultModel                                         \n```",
         "operationId": "_endpoint_predict_some_complex_model_post",
         "requestBody": {
           "content": {

--- a/tests/testdata/library_describe.txt
+++ b/tests/testdata/library_describe.txt
@@ -35,7 +35,7 @@ Models
     ├── doc: More complex                                                       
     │                                                                           
     │           With **a lot** of documentation                                 
-    ├── signature: ItemModel -> ItemModel                                       
+    ├── signature: ItemModel -> ResultModel                                     
     ├── dependencies                                                            
     │   └── some_model_a                                                        
     ├── batch size: 128                                                         


### PR DESCRIPTION
I noticed that the `describe` method returns the input ItemType twice instead of the itemType and Result Type:
`signature: ItemModel -> ItemModel` instead of ` signature: ItemModel -> ResultModel`
This PR fixes this bug.