### PR TITLE
Fix model load time unit

### DIFF
--- a/modelkit/core/library.py
+++ b/modelkit/core/library.py
@@ -190,7 +190,7 @@ class ModelLibrary:
         logger.info(
             "Model and dependencies loaded",
             name=model_name,
-            time=humanize.naturaldelta(m.time, minimum_unit="microseconds"),
+            time=humanize.naturaldelta(m.time, minimum_unit="seconds"),
             time_s=m.time,
             memory=humanize.naturalsize(m.increment)
             if m.increment is not None

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -132,7 +132,7 @@ class Asset:
         logger.debug(
             "Model loaded",
             model_name=self.configuration_key,
-            time=humanize.naturaldelta(m.time, minimum_unit="microseconds"),
+            time=humanize.naturaldelta(m.time, minimum_unit="seconds"),
             time_s=m.time,
             memory=humanize.naturalsize(m.increment)
             if m.increment is not None
@@ -297,7 +297,7 @@ class AbstractModel(Asset, Generic[ItemType, ReturnType]):
         if self._load_time:
             sub_t = t.add(
                 "[deep_sky_blue1]load time[/deep_sky_blue1]: [orange3]"
-                + humanize.naturaldelta(self._load_time, minimum_unit="microseconds")
+                + humanize.naturaldelta(self._load_time, minimum_unit="seconds")
             )
 
         if self._load_memory_increment is not None:


### PR DESCRIPTION
I noticed the model load time unit is wrong.
`time.perf_counter()` differences were analysed in milliseconds while it is actually expressed in seconds.
This PR fixes this bug