### PR TITLE
Improve model describe method with load time and memory including dependencies

### DIFF
--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -305,6 +305,20 @@ class AbstractModel(Asset, Generic[ItemType, ReturnType]):
                 f"[deep_sky_blue1]load memory[/deep_sky_blue1]: "
                 f"[orange3]{humanize.naturalsize(self._load_memory_increment)}"
             )
+
+        global_load_time, global_load_memory = self._compute_dependencies_load_info()
+        sub_t = t.add(
+            "[deep_sky_blue1]load time including dependencies[/deep_sky_blue1]:"
+            + " [orange3]"
+            + humanize.naturaldelta(global_load_time, minimum_unit="seconds")
+        )
+
+        sub_t = t.add(
+            "[deep_sky_blue1]load memory including dependencies[/deep_sky_blue1]:"
+            + " [orange3]"
+            + humanize.naturalsize(global_load_memory)
+        )
+
         if self.model_dependencies.models:
             dep_t = t.add("[deep_sky_blue1]dependencies")
             for m in self.model_dependencies.models:
@@ -326,6 +340,26 @@ class AbstractModel(Asset, Generic[ItemType, ReturnType]):
             describe(self.model_settings, t=sub_t)
 
         return t
+
+    def _compute_dependencies_load_info(self):
+        def add_dependencies_load_info(load_info_dict, my_model):
+            for model_name, model_dep in my_model.model_dependencies.models.items():
+                if model_name not in load_info_dict:
+                    load_info_dict[model_name] = {
+                        "time": model_dep._load_time or 0,
+                        "memory_increment": model_dep._load_memory_increment or 0,
+                    }
+                    add_dependencies_load_info(load_info_dict, model_dep)
+
+        global_load_info = {}
+        add_dependencies_load_info(global_load_info, self)
+        global_load_time = (self._load_memory_increment or 0) + sum(
+            x["memory_increment"] for x in global_load_info.values()
+        )
+        global_load_memory = (self._load_time or 0) + sum(
+            x["time"] for x in global_load_info.values()
+        )
+        return global_load_time, global_load_memory
 
     def _validate(
         self,

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -342,15 +342,6 @@ class AbstractModel(Asset, Generic[ItemType, ReturnType]):
         return t
 
     def _compute_dependencies_load_info(self):
-        def add_dependencies_load_info(load_info_dict, my_model):
-            for model_name, model_dep in my_model.model_dependencies.models.items():
-                if model_name not in load_info_dict:
-                    load_info_dict[model_name] = {
-                        "time": model_dep._load_time or 0,
-                        "memory_increment": model_dep._load_memory_increment or 0,
-                    }
-                    add_dependencies_load_info(load_info_dict, model_dep)
-
         global_load_info = {}
         add_dependencies_load_info(global_load_info, self)
         global_load_time = (self._load_memory_increment or 0) + sum(
@@ -420,6 +411,16 @@ class AbstractModel(Asset, Generic[ItemType, ReturnType]):
             raise NoPredictOverridenError(
                 "_predict or _predict_batch must be overriden"
             )
+
+
+def add_dependencies_load_info(load_info_dict, my_model):
+    for model_name, model_dep in my_model.model_dependencies.models.items():
+        if model_name not in load_info_dict:
+            load_info_dict[model_name] = {
+                "time": model_dep._load_time or 0,
+                "memory_increment": model_dep._load_memory_increment or 0,
+            }
+            add_dependencies_load_info(load_info_dict, model_dep)
 
 
 class CallableWithAttribute(Protocol):

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -7,7 +7,7 @@ import pytest
 from rich.console import Console
 
 from modelkit.core.library import ModelLibrary
-from modelkit.core.model import Model
+from modelkit.core.model import Model, add_dependencies_load_info
 from modelkit.testing import ReferenceText
 from modelkit.utils.pretty import describe
 from tests import TEST_DIR
@@ -200,6 +200,26 @@ def test_describe_load_info():
     for m in ["top", "right", "left", "join_dep", "right_dep"]:
         library.get(m)._load_time = 1
         library.get(m)._load_memory_increment = 1
+
+    load_info_top = {}
+    add_dependencies_load_info(load_info_top, library.get("top"))
+    assert load_info_top == {
+        "right": {"time": 1, "memory_increment": 1},
+        "left": {"time": 1, "memory_increment": 1},
+        "join_dep": {"time": 1, "memory_increment": 1},
+        "right_dep": {"time": 1, "memory_increment": 1},
+    }
+
+    load_info_right = {}
+    add_dependencies_load_info(load_info_right, library.get("right"))
+    assert load_info_right == {
+        "join_dep": {"time": 1, "memory_increment": 1},
+        "right_dep": {"time": 1, "memory_increment": 1},
+    }
+
+    load_info_join_dep = {}
+    add_dependencies_load_info(load_info_join_dep, library.get("join_dep"))
+    assert load_info_join_dep == {}
 
     if platform.system() == "Windows":
         # Output is different on Windows platforms since

--- a/tests/testdata/test_describe_load_info.txt
+++ b/tests/testdata/test_describe_load_info.txt
@@ -1,0 +1,10 @@
+                                                                                
+├── configuration: top                                                          
+├── signature: str -> str                                                       
+├── load time: a second                                                         
+├── load memory: 1 Byte                                                         
+├── load time including dependencies: 5 seconds                                 
+├── load memory including dependencies: 5 Bytes                                 
+└── dependencies                                                                
+    ├── right                                                                   
+    └── left                                                                    


### PR DESCRIPTION
I noticed a model _load_time and _load_memory_increment doesn't include its dependencies info.
It makes sense but I feel that, as we push for composable models, it is more informative to cumulate the model data if all of its dependencies.
@victorbenichoux  what do you think? Is there a specific need to get the model load time and memory without its dependencies?