### PR TITLE
configurations: allow models without CONFIGURATIONS dict

### DIFF
--- a/modelkit/core/model_configuration.py
+++ b/modelkit/core/model_configuration.py
@@ -2,6 +2,7 @@ import importlib
 import inspect
 import os
 import pkgutil
+import re
 from collections import ChainMap
 from types import ModuleType
 from typing import Any, Dict, List, Mapping, Optional, Set, Type, Union
@@ -52,20 +53,33 @@ def walk_objects(mod):
         yield from walk_module_objects(mod, already_seen)
 
 
+TO_SNAKE_CASE_PATTERN = re.compile(r"(?<!^)(?=[A-Z])")
+
+
+def to_snake_case(name):
+    return TO_SNAKE_CASE_PATTERN.sub("_", name).lower()
+
+
 def _configurations_from_objects(m) -> Dict[str, ModelConfiguration]:
     if inspect.isclass(m) and issubclass(m, Asset):
-        return {
-            key: ModelConfiguration(**{**config, "model_type": m})
-            for key, config in m.CONFIGURATIONS.items()
-        }
+        configs = {}
+        if m.CONFIGURATIONS:
+            for key, config in m.CONFIGURATIONS.items():
+                configs[key] = ModelConfiguration(**{**config, "model_type": m})
+        else:
+            configs[to_snake_case(m.__name__)] = ModelConfiguration(model_type=m)
+        return configs
     elif isinstance(m, (list, tuple)):
         return dict(ChainMap(*(_configurations_from_objects(sub_m) for sub_m in m)))
     elif isinstance(m, ModuleType):
-        return {
-            key: ModelConfiguration(**{**config, "model_type": m})
-            for m in walk_objects(m)
-            for key, config in m.CONFIGURATIONS.items()
-        }
+        configs = {}
+        for m in walk_objects(m):
+            if m.CONFIGURATIONS:
+                for key, config in m.CONFIGURATIONS.items():
+                    configs[key] = ModelConfiguration(**{**config, "model_type": m})
+            else:
+                configs[to_snake_case(m.__name__)] = ModelConfiguration(model_type=m)
+        return configs
     elif isinstance(m, str):
         models = [importlib.import_module(modname) for modname in m.split(",")]
         return _configurations_from_objects(models)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -148,7 +148,7 @@ def test__configurations_from_objects():
     assert "les simpsons" in configurations
 
     configurations = _configurations_from_objects(ModelNoConf)
-    assert {} == configurations
+    assert "model_no_conf" in configurations
 
     configurations = _configurations_from_objects([SomeModel, SomeModel2, ModelNoConf])
     assert "yolo" in configurations


### PR DESCRIPTION
Tired of having to add empty `CONFIGURATIONS` attributes to your models?

Look no further, in this PR, I introduce what I think is a neat little feature for `Model`s. Whenever there is _no `CONFIGURATIONS` dict_ defined, the model will still be available with a name corresponding to its class name, but snaked case.

So, 

```python
from modelkit import Model, ModelLibrary

class ModelWithoutConfig(Model):
    def _predict(self, item):
        return item

library = ModelLibrary(models=ModelWithoutConfig)
model = library.get("model_without_config")
```

This is much better, in particular because unless the type is specified fully, `mypy` will complain, so the current alternative is much more verbose:

```python
class ModelWithoutConfig(Model):
    CONFIGURATIONS : Dict[str, Any] = {
        "model_without_config": {}
    }

    def _predict(self, item):
        return item

```
What do you think?
