### PR TITLE
Support usage of inheritance for model definitions

### DIFF
--- a/docs/library/models/organizing.md
+++ b/docs/library/models/organizing.md
@@ -53,8 +53,8 @@ import my_ml_package
 service = ModelLibrary(models=my_ml_package)
 ```
 
-!!! note 
-    It is also possible to refer to a sub module `ModelLibrary(models=package.subpackage)` the `Model` classes themselves `ModelLibrary(models=SomeModelClass)`, string package names `ModelLibrary(models="package.module_2")` or any combination of the above `ModelLibrary(models=[package.subpackage, SomeModelClass])`
+> **Note:**<br>
+It is also possible to refer to a sub module `ModelLibrary(models=package.subpackage)` the `Model` classes themselves `ModelLibrary(models=SomeModelClass)`, string package names `ModelLibrary(models="package.module_2")` or any combination of the above `ModelLibrary(models=[package.subpackage, SomeModelClass])`
 
 In order to restrict the models that are actually being loaded, pass a list of `required_models` keys to the `ModelLibrary` instantiation:
 
@@ -63,4 +63,22 @@ service = ModelLibrary(
     models=[package.module_2, package.subpackage],
     required_models=["some_model"]
 )
+```
+
+### Abstract models
+
+It is possible to define models that inherits from an abstract model in order to share common behavior.
+
+For instance, it can be usefull to implement common prediction algorithm on different data assets
+
+```python
+class BaseModel(AbstractMixin, Model):
+    def _predict(self, item, **kwargs):
+        ...
+
+class DerivedModel(ConcreteMixin, BaseModel):
+    CONFIGURATIONS = {"derived": {"asset": "something.txt"}}
+
+    def _load(self):
+        ...
 ```

--- a/docs/library/special/distant.md
+++ b/docs/library/special/distant.md
@@ -5,8 +5,9 @@ Sometimes models will simply need to call another microservice, in this case `Di
 
 ```python
 from modelkit.core.models.distant_model import DistantHTTPModel
+from modelkit.core.model import ConcreteMixin
 
-class SomeDistantHTTPModel(DistantHTTPModel):
+class SomeDistantHTTPModel(ConcreteMixin, DistantHTTPModel):
     CONFIGURATIONS = {
         "some_model": {
             "model_settings": {

--- a/modelkit/core/model.py
+++ b/modelkit/core/model.py
@@ -81,6 +81,7 @@ class Asset:
     """
 
     CONFIGURATIONS: Dict[str, Dict[str, Any]] = {}
+    _abstract = False
 
     def __init__(
         self,
@@ -785,3 +786,11 @@ class WrappedAsyncModel:
         # The following does not currently work, because AsyncToSync does not
         # seem to correctly wrap asynchronous generators
         # self.predict_gen = AsyncToSync(self.async_model.predict_gen)
+
+
+class AbstractMixin:
+    _abstract = True
+
+
+class ConcreteMixin:
+    _abstract = False

--- a/modelkit/core/model_configuration.py
+++ b/modelkit/core/model_configuration.py
@@ -72,14 +72,11 @@ def _configurations_from_objects(m) -> Dict[str, ModelConfiguration]:
     elif isinstance(m, (list, tuple)):
         return dict(ChainMap(*(_configurations_from_objects(sub_m) for sub_m in m)))
     elif isinstance(m, ModuleType):
-        configs = {}
-        for m in walk_objects(m):
-            if m.CONFIGURATIONS:
-                for key, config in m.CONFIGURATIONS.items():
-                    configs[key] = ModelConfiguration(**{**config, "model_type": m})
-            else:
-                configs[to_snake_case(m.__name__)] = ModelConfiguration(model_type=m)
-        return configs
+        return dict(
+            ChainMap(
+                *(_configurations_from_objects(sub_m) for sub_m in walk_objects(m))
+            )
+        )
     elif isinstance(m, str):
         models = [importlib.import_module(modname) for modname in m.split(",")]
         return _configurations_from_objects(models)

--- a/modelkit/core/model_configuration.py
+++ b/modelkit/core/model_configuration.py
@@ -62,6 +62,8 @@ def to_snake_case(name):
 
 def _configurations_from_objects(m) -> Dict[str, ModelConfiguration]:
     if inspect.isclass(m) and issubclass(m, Asset):
+        if m._abstract:
+            return {}
         configs = {}
         if m.CONFIGURATIONS:
             for key, config in m.CONFIGURATIONS.items():

--- a/modelkit/core/models/distant_model.py
+++ b/modelkit/core/models/distant_model.py
@@ -11,7 +11,7 @@ from tenacity import (
     wait_random_exponential,
 )
 
-from modelkit.core.model import AsyncModel, Model
+from modelkit.core.model import AbstractMixin, AsyncModel, Model
 from modelkit.core.types import ItemType, ReturnType
 
 logger = get_logger(__name__)
@@ -46,7 +46,7 @@ SERVICE_MODEL_RETRY_POLICY = {
 }
 
 
-class AsyncDistantHTTPModel(AsyncModel[ItemType, ReturnType]):
+class AsyncDistantHTTPModel(AbstractMixin, AsyncModel[ItemType, ReturnType]):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.endpoint = self.model_settings["endpoint"]
@@ -77,7 +77,7 @@ class AsyncDistantHTTPModel(AsyncModel[ItemType, ReturnType]):
             return self.aiohttp_session.close()
 
 
-class DistantHTTPModel(Model[ItemType, ReturnType]):
+class DistantHTTPModel(AbstractMixin, Model[ItemType, ReturnType]):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.endpoint = self.model_settings["endpoint"]

--- a/tests/test_distant_http_model.py
+++ b/tests/test_distant_http_model.py
@@ -7,6 +7,7 @@ import pytest
 import requests
 
 from modelkit.core.library import ModelLibrary
+from modelkit.core.model import ConcreteMixin
 from modelkit.core.models.distant_model import AsyncDistantHTTPModel, DistantHTTPModel
 from tests import TEST_DIR
 
@@ -68,12 +69,12 @@ async def test_distant_http_model(
         "async_mode": False,
     }
 
-    class SomeDistantHTTPModel(DistantHTTPModel):
+    class SomeDistantHTTPModel(ConcreteMixin, DistantHTTPModel):
         CONFIGURATIONS = {
             "some_model_sync": {"model_settings": sync_model_settings},
         }
 
-    class SomeAsyncDistantHTTPModel(AsyncDistantHTTPModel):
+    class SomeAsyncDistantHTTPModel(ConcreteMixin, AsyncDistantHTTPModel):
         CONFIGURATIONS = {"some_model_async": {"model_settings": async_model_settings}}
 
     lib_without_params = ModelLibrary(

--- a/tests/testmodels/some_assets.py
+++ b/tests/testmodels/some_assets.py
@@ -1,0 +1,10 @@
+from modelkit.core.model import AbstractMixin, Asset, ConcreteMixin
+
+
+class BaseAsset(AbstractMixin, Asset):
+    def _load(self):
+        assert self.asset_path
+
+
+class DerivedAsset(ConcreteMixin, BaseAsset):
+    CONFIGURATIONS = {"derived_asset": {"asset": "something.txt"}}

--- a/tests/testmodels/some_models.py
+++ b/tests/testmodels/some_models.py
@@ -1,0 +1,13 @@
+from modelkit.core.model import AbstractMixin, ConcreteMixin, Model
+
+
+class BaseModel(AbstractMixin, Model):
+    def _load(self):
+        assert self.asset_path
+
+
+class DerivedModel(ConcreteMixin, BaseModel):
+    CONFIGURATIONS = {"derived_model": {"asset": "something.txt"}}
+
+    def _predict(self, item):
+        return item


### PR DESCRIPTION
After change done in #123, 

Abstract base model that were previously bypassed during `configure` step because of missing CONFIGURATIONS dict are now considered as valid Model to load.

Hence breaking usage where those Abstract base model are part of the same module than the Concrete derived model and we decide to load full python module.

With this change modelkit can support this use-case with small adaptation of client code:
```
class YourABCModel(AbstractMixin, Asset):
    ...

class YourDerivedModel(ConcreteMixin, YourABCModel):
   ...
```
Doing so will ensure ABC model are again bypassed by `configure` step but not the Derived model.
