### PR TITLE
Pickable storage driver clients

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,7 @@
 
 In order to run/deploy `modelkit` endpoints, you need to provide it with the necessary environment variables, most of them required by `modelkit.assets` to retrieve assets from the remote object store:
 
-### General `modelkit` environment variables
+### General `modelkit` environment variables
 
 The assets directory is required to know where to find assets
 
@@ -19,7 +19,12 @@ Lazy loading is useful when you want the models to be loaded only when they are 
 
 - `MODELKIT_LAZY_LOADING` (defaults to `False`) toggles lazy loading mode for the `ModelLibrary`
 
-### Storage related environment variables
+Due to the implementation of cloud drivers, which are not pickable, the lazy driver mode is useful when you want 
+to use the ModelLibrary in conjunction with libraries using pickle: PySpark, multiprocessing etc.
+
+- `MODELKIT_LAZY_DRIVER` (defaults to `False`) toggles lazy mode for the `StorageProvider`'s drivers creation (boto3, gcs, azure)
+
+### Storage related environment variables
 
 These variables are necessary to set a remote storage from which to retrieve assets. Refer to the [storage provider documentation for more information](assets/storage_provider.md) for more information.
 
@@ -33,7 +38,7 @@ These variables are necessary to set a remote storage from which to retrieve ass
     - for `MODELKIT_STORAGE_PROVIDER=s3`, you need to instantiate `AWS_PROFILE`
     - for `MODELKIT_STORAGE_PROVIDER=az`, you need to instantiate `AZURE_STORAGE_CONNECTION_STRING` with a connection string
 
-### Assets versioning related environment variable
+### Assets versioning related environment variable
 
  - `MODELKIT_ASSETS_VERSIONING_SYSTEM` will fix the assets versioning system. It can be `major_minor` or `simple_date`
 

--- a/modelkit/assets/cli.py
+++ b/modelkit/assets/cli.py
@@ -10,6 +10,8 @@ from rich.progress import Progress, SpinnerColumn
 from rich.table import Table
 from rich.tree import Tree
 
+from modelkit.assets.drivers.abc import StorageDriverSettings
+
 try:
     from modelkit.assets.drivers.gcs import GCSStorageDriver
 
@@ -130,18 +132,21 @@ def new_(asset_path, asset_spec, storage_prefix, dry_run):
         with tempfile.TemporaryDirectory() as tmp_dir:
             if not os.path.exists(asset_path):
                 parsed_path = parse_remote_url(asset_path)
+                driver_settings = StorageDriverSettings(
+                    bucket=parsed_path["bucket_name"]
+                )
                 if parsed_path["storage_prefix"] == "gs":
                     if not has_gcs:
                         raise DriverNotInstalledError(
                             "GCS driver not installed, install modelkit[assets-gcs]"
                         )
-                    driver = GCSStorageDriver(bucket=parsed_path["bucket_name"])
+                    driver = GCSStorageDriver(driver_settings)
                 elif parsed_path["storage_prefix"] == "s3":
                     if not has_s3:
                         raise DriverNotInstalledError(
                             "S3 driver not installed, install modelkit[assets-s3]"
                         )
-                    driver = S3StorageDriver(bucket=parsed_path["bucket_name"])
+                    driver = S3StorageDriver(driver_settings)
                 else:
                     raise ValueError(
                         f"Unmanaged storage prefix `{parsed_path['storage_prefix']}`"
@@ -229,18 +234,21 @@ def update_(asset_path, asset_spec, storage_prefix, bump_major, dry_run):
         with tempfile.TemporaryDirectory() as tmp_dir:
             if not os.path.exists(asset_path):
                 parsed_path = parse_remote_url(asset_path)
+                driver_settings = StorageDriverSettings(
+                    bucket=parsed_path["bucket_name"]
+                )
                 if parsed_path["storage_prefix"] == "gs":
                     if not has_gcs:
                         raise DriverNotInstalledError(
                             "GCS driver not installed, install modelkit[assets-gcs]"
                         )
-                    driver = GCSStorageDriver(bucket=parsed_path["bucket_name"])
+                    driver = GCSStorageDriver(driver_settings)
                 elif parsed_path["storage_prefix"] == "s3":
                     if not has_s3:
                         raise DriverNotInstalledError(
                             "S3 driver not installed, install modelkit[assets-s3]"
                         )
-                    driver = S3StorageDriver(bucket=parsed_path["bucket_name"])
+                    driver = S3StorageDriver(driver_settings)
                 else:
                     raise ValueError(
                         f"Unmanaged storage prefix `{parsed_path['storage_prefix']}`"

--- a/modelkit/assets/drivers/abc.py
+++ b/modelkit/assets/drivers/abc.py
@@ -17,7 +17,7 @@ class StorageDriver(abc.ABC):
         self.client_configuration = client_configuration or {}
         self.bucket = bucket or os.environ.get("MODELKIT_STORAGE_BUCKET") or ""
         if not self.bucket:
-            raise ValueError("Bucket needs to be set for Azure storage driver")
+            raise ValueError("Bucket needs to be set for the storage driver")
         self.lazy_driver = os.environ.get("MODELKIT_LAZY_DRIVER")
         if not (self.lazy_driver or client):
             self._client = self.build_client(self.client_configuration)

--- a/modelkit/assets/drivers/abc.py
+++ b/modelkit/assets/drivers/abc.py
@@ -1,9 +1,26 @@
 import abc
-from typing import Iterator, Optional
+import os
+from typing import Any, Dict, Iterator, Optional, Union
 
 
 class StorageDriver(abc.ABC):
     bucket: str
+
+    def __init__(
+        self,
+        bucket: Optional[str],
+        client: Optional[Any] = None,
+        client_configuration: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__()
+        self._client = client
+        self.client_configuration = client_configuration or {}
+        self.bucket = bucket or os.environ.get("MODELKIT_STORAGE_BUCKET") or ""
+        if not self.bucket:
+            raise ValueError("Bucket needs to be set for Azure storage driver")
+        self.lazy_driver = os.environ.get("MODELKIT_LAZY_DRIVER")
+        if not (self.lazy_driver or client):
+            self._client = self.build_client(self.client_configuration)
 
     @abc.abstractmethod
     def iterate_objects(
@@ -33,4 +50,14 @@ class StorageDriver(abc.ABC):
     def get_object_uri(
         self, object_name: str, sub_part: Optional[str] = None
     ) -> str:  # pragma: no cover
+        ...
+
+    @property
+    def client(self):
+        return self._client or self.build_client(self.client_configuration)
+
+    @staticmethod
+    def build_client(
+        client_configuration: Union[Dict[str, Any], Optional[Dict[str, Any]]]
+    ) -> Any:
         ...

--- a/modelkit/assets/drivers/abc.py
+++ b/modelkit/assets/drivers/abc.py
@@ -1,6 +1,6 @@
 import abc
 import os
-from typing import Any, Dict, Iterator, Optional, Union
+from typing import Any, Dict, Iterator, Optional
 
 
 class StorageDriver(abc.ABC):
@@ -57,7 +57,6 @@ class StorageDriver(abc.ABC):
         return self._client or self.build_client(self.client_configuration)
 
     @staticmethod
-    def build_client(
-        client_configuration: Union[Dict[str, Any], Optional[Dict[str, Any]]]
-    ) -> Any:
+    @abc.abstractmethod
+    def build_client(client_configuration: Dict[str, Any]) -> Any:
         ...

--- a/modelkit/assets/drivers/abc.py
+++ b/modelkit/assets/drivers/abc.py
@@ -13,8 +13,6 @@ class StorageDriverSettings(pydantic.BaseSettings):
 
 
 class StorageDriver(abc.ABC):
-    bucket: str
-
     def __init__(
         self,
         settings: Union[Dict, StorageDriverSettings],

--- a/modelkit/assets/drivers/azure.py
+++ b/modelkit/assets/drivers/azure.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, Optional, Union
+from typing import Dict, Optional
 
 from azure.storage.blob import BlobServiceClient
 from structlog import get_logger
@@ -36,10 +36,8 @@ class AzureStorageDriver(StorageDriver):
         )
 
     @staticmethod
-    def build_client(
-        client_configuration: Union[Dict[str, Any], Optional[Dict[str, Any]]]
-    ) -> BlobServiceClient:
-        connection_string = (client_configuration or {}).get("connection_string")
+    def build_client(client_configuration: Dict[str, str]) -> BlobServiceClient:
+        connection_string = client_configuration.get("connection_string")
         if not connection_string:
             raise ValueError(
                 "Connection string needs to be set for Azure storage driver"

--- a/modelkit/assets/drivers/azure.py
+++ b/modelkit/assets/drivers/azure.py
@@ -25,8 +25,6 @@ class AzureStorageDriverSettings(StorageDriverSettings):
 
 
 class AzureStorageDriver(StorageDriver):
-    bucket: str
-
     def __init__(
         self,
         settings: Union[Dict, AzureStorageDriverSettings],

--- a/modelkit/assets/drivers/azure.py
+++ b/modelkit/assets/drivers/azure.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional
+from typing import Any, Dict, Optional, Union
 
 from azure.storage.blob import BlobServiceClient
 from structlog import get_logger
@@ -23,18 +23,28 @@ class AzureStorageDriver(StorageDriver):
         connection_string: Optional[str] = None,
         client: Optional[BlobServiceClient] = None,
     ):
-        self.bucket = bucket or os.environ.get("MODELKIT_STORAGE_BUCKET") or ""
-        if not self.bucket:
-            raise ValueError("Bucket needs to be set for Azure storage driver")
-
-        if client:
-            self.client = client
-        elif connection_string:  # pragma: no cover
-            self.client = BlobServiceClient.from_connection_string(connection_string)
-        else:
-            self.client = BlobServiceClient.from_connection_string(
-                os.environ["AZURE_STORAGE_CONNECTION_STRING"]
+        client_configuration = {
+            "connection_string": connection_string
+            or os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
+        }
+        if not (client or client_configuration["connection_string"]):
+            raise ValueError(
+                "Connection string needs to be set for Azure storage driver"
             )
+        super().__init__(
+            bucket=bucket, client=client, client_configuration=client_configuration
+        )
+
+    @staticmethod
+    def build_client(
+        client_configuration: Union[Dict[str, Any], Optional[Dict[str, Any]]]
+    ) -> BlobServiceClient:
+        connection_string = (client_configuration or {}).get("connection_string")
+        if not connection_string:
+            raise ValueError(
+                "Connection string needs to be set for Azure storage driver"
+            )
+        return BlobServiceClient.from_connection_string(connection_string)
 
     @retry(**AZURE_RETRY_POLICY)
     def iterate_objects(self, prefix=None):

--- a/modelkit/assets/drivers/gcs.py
+++ b/modelkit/assets/drivers/gcs.py
@@ -1,6 +1,7 @@
 import os
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
+import pydantic
 from google.api_core.exceptions import GoogleAPIError, NotFound
 from google.cloud import storage
 from google.cloud.storage import Client
@@ -8,7 +9,7 @@ from structlog import get_logger
 from tenacity import retry
 
 from modelkit.assets import errors
-from modelkit.assets.drivers.abc import StorageDriver
+from modelkit.assets.drivers.abc import StorageDriver, StorageDriverSettings
 from modelkit.assets.drivers.retry import retry_policy
 
 logger = get_logger(__name__)
@@ -16,18 +17,32 @@ logger = get_logger(__name__)
 GCS_RETRY_POLICY = retry_policy(GoogleAPIError)
 
 
+class GCSStorageDriverSettings(StorageDriverSettings):
+    service_account_path: Optional[str] = pydantic.Field(
+        None, env="GOOGLE_APPLICATION_CREDENTIALS"
+    )
+
+    class Config:
+        extra = "forbid"
+
+
 class GCSStorageDriver(StorageDriver):
     bucket: str
 
     def __init__(
         self,
-        bucket: Optional[str] = None,
-        service_account_path: Optional[str] = None,
+        settings: Union[Dict, GCSStorageDriverSettings],
         client: Optional[Client] = None,
     ):
-        client_configuration = {"service_account_path": service_account_path}
+        if isinstance(settings, dict):
+            settings = GCSStorageDriverSettings(**settings)
+
         super().__init__(
-            bucket=bucket, client=client, client_configuration=client_configuration
+            settings=settings,
+            client=client,
+            client_configuration={
+                "service_account_path": settings.service_account_path
+            },
         )
 
     @staticmethod

--- a/modelkit/assets/drivers/gcs.py
+++ b/modelkit/assets/drivers/gcs.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional
+from typing import Dict, Optional
 
 from google.api_core.exceptions import GoogleAPIError, NotFound
 from google.cloud import storage
@@ -18,7 +18,6 @@ GCS_RETRY_POLICY = retry_policy(GoogleAPIError)
 
 class GCSStorageDriver(StorageDriver):
     bucket: str
-    client: Client
 
     def __init__(
         self,
@@ -26,16 +25,17 @@ class GCSStorageDriver(StorageDriver):
         service_account_path: Optional[str] = None,
         client: Optional[Client] = None,
     ):
-        self.bucket = bucket or os.environ.get("MODELKIT_STORAGE_BUCKET") or ""
-        if not self.bucket:
-            raise ValueError("Bucket needs to be set for GCS storage driver")
+        client_configuration = {"service_account_path": service_account_path}
+        super().__init__(
+            bucket=bucket, client=client, client_configuration=client_configuration
+        )
 
-        if client:
-            self.client = client
-        elif service_account_path:  # pragma: no cover
-            self.client = Client.from_service_account_json(service_account_path)
-        else:
-            self.client = Client()
+    @staticmethod
+    def build_client(client_configuration: Optional[Dict[str, str]]) -> Client:
+        sa_path = (client_configuration or {}).get("service_account_path")
+        if sa_path:
+            return Client.from_service_account_json(sa_path)
+        return Client()
 
     @retry(**GCS_RETRY_POLICY)
     def iterate_objects(self, prefix=None):

--- a/modelkit/assets/drivers/gcs.py
+++ b/modelkit/assets/drivers/gcs.py
@@ -27,8 +27,6 @@ class GCSStorageDriverSettings(StorageDriverSettings):
 
 
 class GCSStorageDriver(StorageDriver):
-    bucket: str
-
     def __init__(
         self,
         settings: Union[Dict, GCSStorageDriverSettings],

--- a/modelkit/assets/drivers/gcs.py
+++ b/modelkit/assets/drivers/gcs.py
@@ -31,8 +31,8 @@ class GCSStorageDriver(StorageDriver):
         )
 
     @staticmethod
-    def build_client(client_configuration: Optional[Dict[str, str]]) -> Client:
-        sa_path = (client_configuration or {}).get("service_account_path")
+    def build_client(client_configuration: Dict[str, str]) -> Client:
+        sa_path = client_configuration.get("service_account_path")
         if sa_path:
             return Client.from_service_account_json(sa_path)
         return Client()

--- a/modelkit/assets/drivers/local.py
+++ b/modelkit/assets/drivers/local.py
@@ -1,7 +1,7 @@
 import glob
 import os
 import shutil
-from typing import Any, Optional
+from typing import Dict, Optional
 
 from structlog import get_logger
 
@@ -20,7 +20,7 @@ class LocalStorageDriver(StorageDriver):
             raise FileNotFoundError
 
     @staticmethod
-    def build_client(_: Any) -> None:
+    def build_client(_: Dict[str, str]) -> None:
         return None
 
     def iterate_objects(self, prefix: Optional[str] = None):

--- a/modelkit/assets/drivers/local.py
+++ b/modelkit/assets/drivers/local.py
@@ -1,21 +1,28 @@
 import glob
 import os
 import shutil
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 from structlog import get_logger
 
 from modelkit.assets import errors
-from modelkit.assets.drivers.abc import StorageDriver
+from modelkit.assets.drivers.abc import StorageDriver, StorageDriverSettings
 
 logger = get_logger(__name__)
+
+
+class LocalStorageDriverSettings(StorageDriverSettings):
+    class Config:
+        extra = "forbid"
 
 
 class LocalStorageDriver(StorageDriver):
     bucket: str
 
-    def __init__(self, bucket: Optional[str] = None):
-        super().__init__(bucket=bucket)
+    def __init__(self, settings: Union[Dict, LocalStorageDriverSettings]):
+        if isinstance(settings, dict):
+            settings = LocalStorageDriverSettings(**settings)
+        super().__init__(settings)
         if not os.path.isdir(self.bucket):
             raise FileNotFoundError
 

--- a/modelkit/assets/drivers/local.py
+++ b/modelkit/assets/drivers/local.py
@@ -17,8 +17,6 @@ class LocalStorageDriverSettings(StorageDriverSettings):
 
 
 class LocalStorageDriver(StorageDriver):
-    bucket: str
-
     def __init__(self, settings: Union[Dict, LocalStorageDriverSettings]):
         if isinstance(settings, dict):
             settings = LocalStorageDriverSettings(**settings)

--- a/modelkit/assets/drivers/local.py
+++ b/modelkit/assets/drivers/local.py
@@ -1,7 +1,7 @@
 import glob
 import os
 import shutil
-from typing import Optional
+from typing import Any, Optional
 
 from structlog import get_logger
 
@@ -15,11 +15,13 @@ class LocalStorageDriver(StorageDriver):
     bucket: str
 
     def __init__(self, bucket: Optional[str] = None):
-        self.bucket = bucket or os.environ.get("MODELKIT_STORAGE_BUCKET") or ""
-        if not self.bucket:
-            raise ValueError("Bucket needs to be set for local storage driver")
+        super().__init__(bucket=bucket)
         if not os.path.isdir(self.bucket):
             raise FileNotFoundError
+
+    @staticmethod
+    def build_client(_: Any) -> None:
+        return None
 
     def iterate_objects(self, prefix: Optional[str] = None):
         for filename in glob.iglob(

--- a/modelkit/assets/drivers/s3.py
+++ b/modelkit/assets/drivers/s3.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, Optional, Union
+from typing import Dict, Optional
 
 import boto3
 import botocore
@@ -47,10 +47,8 @@ class S3StorageDriver(StorageDriver):
         self.aws_kms_key_id = aws_kms_key_id or os.environ.get("AWS_KMS_KEY_ID")
 
     @staticmethod
-    def build_client(
-        client_configuration: Union[Dict[str, Any], Optional[Dict[str, Any]]]
-    ) -> boto3.client:
-        return boto3.client("s3", **(client_configuration or {}))
+    def build_client(client_configuration: Dict[str, str]) -> boto3.client:
+        return boto3.client("s3", **client_configuration)
 
     @retry(**S3_RETRY_POLICY)
     def iterate_objects(self, prefix=None):

--- a/modelkit/assets/drivers/s3.py
+++ b/modelkit/assets/drivers/s3.py
@@ -31,9 +31,6 @@ class S3StorageDriverSettings(StorageDriverSettings):
 
 
 class S3StorageDriver(StorageDriver):
-    bucket: str
-    endpoint_url: Optional[str]
-
     def __init__(
         self,
         settings: Union[Dict, S3StorageDriverSettings],

--- a/modelkit/assets/drivers/s3.py
+++ b/modelkit/assets/drivers/s3.py
@@ -1,18 +1,33 @@
 import os
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 import boto3
 import botocore
+import pydantic
 from structlog import get_logger
 from tenacity import retry
 
 from modelkit.assets import errors
-from modelkit.assets.drivers.abc import StorageDriver
+from modelkit.assets.drivers.abc import StorageDriver, StorageDriverSettings
 from modelkit.assets.drivers.retry import retry_policy
 
 logger = get_logger(__name__)
 
 S3_RETRY_POLICY = retry_policy(botocore.exceptions.ClientError)
+
+
+class S3StorageDriverSettings(StorageDriverSettings):
+    aws_access_key_id: Optional[str] = pydantic.Field(None, env="AWS_ACCESS_KEY_ID")
+    aws_secret_access_key: Optional[str] = pydantic.Field(
+        None, env="AWS_SECRET_ACCESS_KEY"
+    )
+    aws_default_region: Optional[str] = pydantic.Field(None, env="AWS_DEFAULT_REGION")
+    aws_session_token: Optional[str] = pydantic.Field(None, env="AWS_SESSION_TOKEN")
+    s3_endpoint: Optional[str] = pydantic.Field(None, env="S3_ENDPOINT")
+    aws_kms_key_id: Optional[str] = pydantic.Field(None, env="AWS_KMS_KEY_ID")
+
+    class Config:
+        extra = "forbid"
 
 
 class S3StorageDriver(StorageDriver):
@@ -21,30 +36,23 @@ class S3StorageDriver(StorageDriver):
 
     def __init__(
         self,
-        bucket: Optional[str] = None,
+        settings: Union[Dict, S3StorageDriverSettings],
         client: Optional[boto3.client] = None,
-        aws_access_key_id: Optional[str] = None,
-        aws_secret_access_key: Optional[str] = None,
-        aws_default_region: Optional[str] = None,
-        aws_session_token: Optional[str] = None,
-        aws_kms_key_id: Optional[str] = None,
-        s3_endpoint: Optional[str] = None,
     ):
+        if isinstance(settings, dict):
+            settings = S3StorageDriverSettings(**settings)
 
         client_configuration = {
-            "endpoint_url": s3_endpoint or os.environ.get("S3_ENDPOINT"),
-            "aws_access_key_id": aws_access_key_id
-            or os.environ.get("AWS_ACCESS_KEY_ID"),
-            "aws_secret_access_key": aws_secret_access_key
-            or os.environ.get("AWS_SECRET_ACCESS_KEY"),
-            "region_name": aws_default_region or os.environ.get("AWS_DEFAULT_REGION"),
-            "aws_session_token": aws_session_token
-            or os.environ.get("AWS_SESSION_TOKEN"),
+            "endpoint_url": settings.s3_endpoint,
+            "aws_access_key_id": settings.aws_access_key_id,
+            "aws_secret_access_key": settings.aws_secret_access_key,
+            "region_name": settings.aws_default_region,
+            "aws_session_token": settings.aws_session_token,
         }
+        self.aws_kms_key_id = settings.aws_kms_key_id
         super().__init__(
-            bucket=bucket, client=client, client_configuration=client_configuration
+            settings=settings, client=client, client_configuration=client_configuration
         )
-        self.aws_kms_key_id = aws_kms_key_id or os.environ.get("AWS_KMS_KEY_ID")
 
     @staticmethod
     def build_client(client_configuration: Dict[str, str]) -> boto3.client:

--- a/modelkit/assets/drivers/s3.py
+++ b/modelkit/assets/drivers/s3.py
@@ -23,6 +23,7 @@ class S3StorageDriver(StorageDriver):
     def __init__(
         self,
         bucket: Optional[str] = None,
+        client: Optional[boto3.client] = None,
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         aws_default_region: Optional[str] = None,

--- a/modelkit/assets/remote.py
+++ b/modelkit/assets/remote.py
@@ -4,7 +4,7 @@ import json
 import os
 import tempfile
 import time
-from typing import Optional
+from typing import Any, Optional
 
 import humanize
 from dateutil import parser, tz
@@ -14,21 +14,24 @@ from modelkit.assets import errors
 from modelkit.assets.drivers.abc import StorageDriver
 
 try:
-    from modelkit.assets.drivers.azure import AzureStorageDriver
+    from modelkit.assets.drivers.azure import (
+        AzureStorageDriver,
+        AzureStorageDriverSettings,
+    )
 
     has_az = True
 except ModuleNotFoundError:
     has_az = False
 try:
-    from modelkit.assets.drivers.gcs import GCSStorageDriver
+    from modelkit.assets.drivers.gcs import GCSStorageDriver, GCSStorageDriverSettings
 
     has_gcs = True
 except ModuleNotFoundError:
     has_gcs = False
-from modelkit.assets.drivers.local import LocalStorageDriver
+from modelkit.assets.drivers.local import LocalStorageDriver, LocalStorageDriverSettings
 
 try:
-    from modelkit.assets.drivers.s3 import S3StorageDriver
+    from modelkit.assets.drivers.s3 import S3StorageDriver, S3StorageDriverSettings
 
     has_s3 = True
 except ModuleNotFoundError:
@@ -73,6 +76,7 @@ class StorageProvider:
         prefix: Optional[str] = None,
         force_download: Optional[bool] = None,
         provider: Optional[str] = None,
+        client: Optional[Any] = None,
         **driver_settings,
     ):
         self.timeout = timeout_s or int(
@@ -94,21 +98,25 @@ class StorageProvider:
                 raise DriverNotInstalledError(
                     "GCS driver not installed, install modelkit[assets-gcs]"
                 )
-            self.driver = GCSStorageDriver(**driver_settings)
+            gcs_driver_settings = GCSStorageDriverSettings(**driver_settings)
+            self.driver = GCSStorageDriver(gcs_driver_settings, client)
         elif provider == "s3":
             if not has_s3:
                 raise DriverNotInstalledError(
                     "S3 driver not installed, install modelkit[assets-s3]"
                 )
-            self.driver = S3StorageDriver(**driver_settings)
+            s3_driver_settings = S3StorageDriverSettings(**driver_settings)
+            self.driver = S3StorageDriver(s3_driver_settings, client)
         elif provider == "local":
-            self.driver = LocalStorageDriver(**driver_settings)
+            local_driver_settings = LocalStorageDriverSettings(**driver_settings)
+            self.driver = LocalStorageDriver(local_driver_settings)
         elif provider == "az":
             if not has_az:
                 raise DriverNotInstalledError(
                     "Azure driver not installed, install modelkit[assets-az]"
                 )
-            self.driver = AzureStorageDriver(**driver_settings)
+            az_driver_settings = AzureStorageDriverSettings(**driver_settings)
+            self.driver = AzureStorageDriver(az_driver_settings, client)
         else:
             raise UnknownDriverError()
 

--- a/tests/assets/test_drivers.py
+++ b/tests/assets/test_drivers.py
@@ -1,6 +1,9 @@
 import os
+import pickle
 import tempfile
+from typing import Optional
 
+from modelkit.assets.drivers.abc import StorageDriver
 from modelkit.assets.drivers.local import LocalStorageDriver
 from tests import TEST_DIR
 from tests.conftest import skip_unless
@@ -31,8 +34,20 @@ def _perform_driver_test(driver):
     assert not driver.exists("some/object")
 
 
+def _perform_pickability_test(driver, monkeypatch):
+    # check whether the driver is pickable when
+    # no client is passed at instantation.
+    # Hence the need to set driver's _client property to None
+    monkeypatch.setattr(driver, "_client", None)
+    assert pickle.dumps(driver)
+
+
 def test_local_driver(local_assetsmanager):
     _perform_driver_test(local_assetsmanager.storage_provider.driver)
+
+
+def test_local_driver_pickable(local_assetsmanager, monkeypatch):
+    _perform_pickability_test(local_assetsmanager.storage_provider.driver, monkeypatch)
 
 
 @skip_unless("ENABLE_GCS_TEST", "True")
@@ -40,14 +55,29 @@ def test_gcs_driver(gcs_assetsmanager):
     _perform_driver_test(gcs_assetsmanager.storage_provider.driver)
 
 
+@skip_unless("ENABLE_GCS_TEST", "True")
+def test_gcs_driver_pickable(gcs_assetsmanager, monkeypatch):
+    _perform_pickability_test(gcs_assetsmanager.storage_provider.driver, monkeypatch)
+
+
 @skip_unless("ENABLE_S3_TEST", "True")
 def test_s3_driver(s3_assetsmanager):
     _perform_driver_test(s3_assetsmanager.storage_provider.driver)
 
 
+@skip_unless("ENABLE_S3_TEST", "True")
+def test_s3_driver_pickable(s3_assetsmanager, monkeypatch):
+    _perform_pickability_test(s3_assetsmanager.storage_provider.driver, monkeypatch)
+
+
 @skip_unless("ENABLE_AZ_TEST", "True")
 def test_az_driver(az_assetsmanager):
     _perform_driver_test(az_assetsmanager.storage_provider.driver)
+
+
+@skip_unless("ENABLE_AZ_TEST", "True")
+def test_az_driver_pickable(az_assetsmanager, monkeypatch):
+    _perform_pickability_test(az_assetsmanager.storage_provider.driver, monkeypatch)
 
 
 def test_local_driver_overwrite(working_dir):
@@ -71,3 +101,55 @@ def test_local_driver_overwrite(working_dir):
         os.path.join(TEST_DIR, "assets", "testdata", "some_data.json"), "a/b/c"
     )
     assert os.path.isfile(os.path.join(working_dir, "a", "b", "c"))
+
+
+def test_storage_driver_client(monkeypatch):
+    class MockedDriver(StorageDriver):
+        @staticmethod
+        def build_client(_):
+            return {"built": True, "passed": False}
+
+        def delete_object(self, object_name: str):
+            ...
+
+        def download_object(self, object_name: str, destination_path: str):
+            ...
+
+        def exists(self, object_name: str) -> bool:
+            ...
+
+        def upload_object(self, file_path: str, object_name: str):
+            ...
+
+        def get_object_uri(self, object_name: str, sub_part: Optional[str] = None):
+            ...
+
+        def iterate_objects(self, prefix: Optional[str] = None):
+            ...
+
+    # the storage provider should not build the client
+    # since passed at instantiation
+    driver = MockedDriver(bucket="bucket", client={"built": False, "passed": True})
+    assert driver._client is not None
+    assert driver._client == driver.client == {"built": False, "passed": True}
+
+    # the storage provider should build the client at init
+    driver = MockedDriver(bucket="bucket")
+    assert driver._client is not None
+    assert driver._client == driver.client == {"built": True, "passed": False}
+
+    monkeypatch.setenv("MODELKIT_LAZY_DRIVER", True)
+    # the storage provider should not build the client eagerly nor store it
+    # since MODELKIT_LAZY_DRIVER is set
+    driver = MockedDriver(bucket="bucket")
+    assert driver._client is None
+    # the storage provider builds it on-the-fly when accessed via the `client` property
+    assert driver.client == {"built": True, "passed": False}
+    # but does not store it
+    assert driver._client is None
+
+    # the storage provider should not build any client but use the one passed
+    # at instantiation
+    driver = MockedDriver(bucket="bucket", client={"built": False, "passed": True})
+    assert driver._client is not None
+    assert driver._client == driver.client == {"built": False, "passed": True}


### PR DESCRIPTION
Hi !

This PR aims at adding a way to pickle the `ModelLibrary` which, for the moment, is impossible due to storage drivers (especially boto3 and gcs).

It introduces a `MODELKIT_LAZY_DRIVER` environment variable which, if set, will prevent the `Storage Providers` from storing the drivers (boto3, gcs, azure), instead, the configuration settings will be stored allowing the corresponding `Storage Provider` to build it on the fly.

This will make way easier the use of python libraries which use `pickle` such as Apache Spark and multi-processing, leveraging modelkit.

Thanks for reviewing, as always!