### PR TITLE
setup: pin pydantic to <2.0 to avoid breaking changes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
 	click
 	filelock
 	humanize
-	pydantic
+	pydantic<2.0
 	python-dateutil
 	redis
 	requests


### PR DESCRIPTION
In this PR I pin pydantic in the `install_requires` of `setup.cfg` such that dependency resolvers don't automatically bump pydantic to 2.*

https://github.com/Cornerstone-OnDemand/modelkit/issues/189