### PR TITLE
Fix distant http model json encoding

### DIFF
--- a/modelkit/core/models/distant_model.py
+++ b/modelkit/core/models/distant_model.py
@@ -67,10 +67,16 @@ class AsyncDistantHTTPModel(AsyncModel[ItemType, ReturnType]):
     async def _predict(self, item, **kwargs):
         if self.aiohttp_session is None:
             self.aiohttp_session = aiohttp.ClientSession()
+        try:
+            item = json.dumps(item)
+        except TypeError:
+            # TypeError: Object of type {ItemType} is not JSON serializable
+            # Try converting the pydantic model to json directly
+            item = item.json()
         async with self.aiohttp_session.post(
             self.endpoint,
             params=kwargs.get("endpoint_params", self.endpoint_params),
-            data=json.dumps(item),
+            data=item,
             headers={"content-type": "application/json"},
         ) as response:
             if response.status != 200:
@@ -104,10 +110,16 @@ class DistantHTTPModel(Model[ItemType, ReturnType]):
     def _predict(self, item, **kwargs):
         if not self.requests_session:
             self.requests_session = requests.Session()
+        try:
+            item = json.dumps(item)
+        except TypeError:
+            # TypeError: Object of type {ItemType} is not JSON serializable
+            # Try converting the pydantic model to json directly
+            item = item.json()
         response = self.requests_session.post(
             self.endpoint,
             params=kwargs.get("endpoint_params", self.endpoint_params),
-            data=json.dumps(item),
+            data=item,
             headers={"content-type": "application/json"},
         )
         if response.status_code != 200:
@@ -146,10 +158,16 @@ class DistantHTTPBatchModel(Model[ItemType, ReturnType]):
     def _predict_batch(self, items, **kwargs):
         if not self.requests_session:
             self.requests_session = requests.Session()
+        try:
+            items = json.dumps(items)
+        except TypeError:
+            # TypeError: Object of type {ItemType} is not JSON serializable
+            # Try converting a list of pydantic models to dict
+            items = json.dumps([item.dict() for item in items])
         response = self.requests_session.post(
             self.endpoint,
             params=kwargs.get("endpoint_params", self.endpoint_params),
-            data=json.dumps(items),
+            data=items,
             headers={"content-type": "application/json"},
         )
         if response.status_code != 200:
@@ -185,10 +203,17 @@ class AsyncDistantHTTPBatchModel(AsyncModel[ItemType, ReturnType]):
     async def _predict_batch(self, items, **kwargs):
         if self.aiohttp_session is None:
             self.aiohttp_session = aiohttp.ClientSession()
+        try:
+            items = json.dumps(items)
+        except TypeError:
+            # TypeError: Object of type {ItemType} is not JSON serializable
+            # Try converting a list of pydantic models to dict
+            items = json.dumps([item.dict() for item in items])
+
         async with self.aiohttp_session.post(
             self.endpoint,
             params=kwargs.get("endpoint_params", self.endpoint_params),
-            data=json.dumps(items),
+            data=items,
             headers={"content-type": "application/json"},
         ) as response:
             if response.status != 200:

--- a/tests/test_distant_http_model.py
+++ b/tests/test_distant_http_model.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import time
 
+import pydantic
 import pytest
 import requests
 
@@ -39,13 +40,27 @@ def run_mocked_service():
     proc.terminate()
 
 
+class SomeContentModel(pydantic.BaseModel):
+    some_content: str
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "item,params,expected",
     [
         ({"some_content": "something"}, {}, {"some_content": "something"}),
         (
+            SomeContentModel(**{"some_content": "something"}),
+            {},
             {"some_content": "something"},
+        ),
+        (
+            {"some_content": "something"},
+            {"limit": 10},
+            {"some_content": "something", "limit": 10},
+        ),
+        (
+            SomeContentModel(**{"some_content": "something"}),
             {"limit": 10},
             {"some_content": "something", "limit": 10},
         ),
@@ -55,7 +70,17 @@ def run_mocked_service():
             {"some_content": "something", "skip": 5},
         ),
         (
+            SomeContentModel(**{"some_content": "something"}),
+            {"skip": 5},
+            {"some_content": "something", "skip": 5},
+        ),
+        (
             {"some_content": "something"},
+            {"limit": 10, "skip": 5},
+            {"some_content": "something", "limit": 10, "skip": 5},
+        ),
+        (
+            SomeContentModel(**{"some_content": "something"}),
             {"limit": 10, "skip": 5},
             {"some_content": "something", "limit": 10, "skip": 5},
         ),
@@ -108,6 +133,10 @@ async def test_distant_http_model(
         assert expected == m(item, endpoint_params=params)
 
 
+class SomeOtherContentModel(pydantic.BaseModel):
+    some_other_content: str
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "items, params, expected",
@@ -118,7 +147,26 @@ async def test_distant_http_model(
             [{"some_content": "something"}, {"some_other_content": "something_else"}],
         ),
         (
+            [
+                SomeContentModel(**{"some_content": "something"}),
+                SomeOtherContentModel(**{"some_other_content": "something_else"}),
+            ],
+            {},
             [{"some_content": "something"}, {"some_other_content": "something_else"}],
+        ),
+        (
+            [{"some_content": "something"}, {"some_other_content": "something_else"}],
+            {"limit": 10},
+            [
+                {"some_content": "something", "limit": 10},
+                {"some_other_content": "something_else", "limit": 10},
+            ],
+        ),
+        (
+            [
+                SomeContentModel(**{"some_content": "something"}),
+                SomeOtherContentModel(**{"some_other_content": "something_else"}),
+            ],
             {"limit": 10},
             [
                 {"some_content": "something", "limit": 10},
@@ -134,7 +182,29 @@ async def test_distant_http_model(
             ],
         ),
         (
+            [
+                SomeContentModel(**{"some_content": "something"}),
+                SomeOtherContentModel(**{"some_other_content": "something_else"}),
+            ],
+            {"skip": 5},
+            [
+                {"some_content": "something", "skip": 5},
+                {"some_other_content": "something_else", "skip": 5},
+            ],
+        ),
+        (
             [{"some_content": "something"}, {"some_other_content": "something_else"}],
+            {"limit": 10, "skip": 5},
+            [
+                {"some_content": "something", "limit": 10, "skip": 5},
+                {"some_other_content": "something_else", "limit": 10, "skip": 5},
+            ],
+        ),
+        (
+            [
+                SomeContentModel(**{"some_content": "something"}),
+                SomeOtherContentModel(**{"some_other_content": "something_else"}),
+            ],
             {"limit": 10, "skip": 5},
             [
                 {"some_content": "something", "limit": 10, "skip": 5},


### PR DESCRIPTION
Hi 👋 
This PR introduces a fix as part of the HTTP distant models which currently do not support pydantic models as ItemType during the json serialization before sending requests.

This PR has been split into 2 commits:
- the first one aims at showing the issue
- the second one solves it

We might want to squash those two commits before merging :) 

Looking forward to have your feedback on this, thanks!