### PR TITLE
library settings: allow extra

### DIFF
--- a/modelkit/core/settings.py
+++ b/modelkit/core/settings.py
@@ -72,3 +72,4 @@ class LibrarySettings(pydantic.BaseSettings):
 
     class Config:
         env_prefix = ""
+        extra = "allow"


### PR DESCRIPTION
Hi 👋 

This PR's only aim is to allow extra fields as part of `LibrarySettings`.

This feature comes from the fact that we should be able to store custom settings when instantiating a `ModelLibrary` with a `LibrarySettings`.

A few use-cases I have come across:
- sharing an `aiohttp` `ClientSession` to all async models of my `ModelLibrary`, as recommended by the [reference](https://docs.aiohttp.org/en/stable/client_reference.html)
- sharing the main thread event loop
- TL;DR: sharing settings instantiated and set up at startup time

Looking forward to your feedback