### PR TITLE
tensorflow model: fix TensorflowModelMixin usage

### DIFF
--- a/modelkit/core/models/tensorflow_model.py
+++ b/modelkit/core/models/tensorflow_model.py
@@ -57,6 +57,9 @@ class TensorflowModelMixin(abc.ABC):
             raise ImportError(
                 "Tensorflow is not installed, instal modelkit[tensorflow]."
             )
+        # this mixing implementing __init__
+        # we need to call super().__init__ to call the Model.__init__
+        super().__init__(*args, **kwargs)
 
     def _is_empty(self, item) -> bool:
         return False
@@ -87,7 +90,7 @@ class TensorflowModelMixin(abc.ABC):
         return results
 
 
-class TensorflowModel(Model[ItemType, ReturnType], TensorflowModelMixin):
+class TensorflowModel(TensorflowModelMixin, Model[ItemType, ReturnType]):
     def __init__(
         self,
         output_tensor_mapping: Optional[Dict[str, str]] = None,
@@ -278,7 +281,7 @@ class TensorflowModel(Model[ItemType, ReturnType], TensorflowModelMixin):
             return self.requests_session.close()
 
 
-class AsyncTensorflowModel(AsyncModel[ItemType, ReturnType], TensorflowModelMixin):
+class AsyncTensorflowModel(TensorflowModelMixin, AsyncModel[ItemType, ReturnType]):
     def __init__(
         self,
         output_tensor_mapping: Optional[Dict[str, str]] = None,

--- a/modelkit/core/models/tensorflow_model.py
+++ b/modelkit/core/models/tensorflow_model.py
@@ -57,8 +57,6 @@ class TensorflowModelMixin(abc.ABC):
             raise ImportError(
                 "Tensorflow is not installed, instal modelkit[tensorflow]."
             )
-        # this mixing implementing __init__
-        # we need to call super().__init__ to call the Model.__init__
         super().__init__(*args, **kwargs)
 
     def _is_empty(self, item) -> bool:


### PR DESCRIPTION
Hi,

Following the discussions around MRO, I noticed an issue with regards to the way we use the `TensorflowModelMixin`.

- Before: its initialization is never called, hence the`ImportError` if `tensorflow` is missing is never raised and a cryptic error is raised later on

- After this PR: its initialization is called, and directly raises the `ImportError` if `tensorflow` is missing.

Thanks for your review