### PR TITLE
storage driver settings: ignore extra

### DIFF
--- a/modelkit/assets/drivers/azure.py
+++ b/modelkit/assets/drivers/azure.py
@@ -22,7 +22,7 @@ class AzureStorageDriverSettings(StorageDriverSettings):
             "connection_string", "AZURE_STORAGE_CONNECTION_STRING"
         ),
     )
-    model_config = pydantic.ConfigDict(extra="forbid")
+    model_config = pydantic.ConfigDict(extra="ignore")
 
 
 class AzureStorageDriver(StorageDriver):

--- a/modelkit/assets/drivers/gcs.py
+++ b/modelkit/assets/drivers/gcs.py
@@ -24,7 +24,7 @@ class GCSStorageDriverSettings(StorageDriverSettings):
             "service_account_path", "GOOGLE_APPLICATION_CREDENTIALS"
         ),
     )
-    model_config = pydantic.ConfigDict(extra="forbid")
+    model_config = pydantic.ConfigDict(extra="ignore")
 
 
 class GCSStorageDriver(StorageDriver):

--- a/modelkit/assets/drivers/local.py
+++ b/modelkit/assets/drivers/local.py
@@ -13,7 +13,7 @@ logger = get_logger(__name__)
 
 
 class LocalStorageDriverSettings(StorageDriverSettings):
-    model_config = pydantic.ConfigDict(extra="forbid")
+    model_config = pydantic.ConfigDict(extra="ignore")
 
 
 class LocalStorageDriver(StorageDriver):

--- a/modelkit/assets/drivers/s3.py
+++ b/modelkit/assets/drivers/s3.py
@@ -47,7 +47,7 @@ class S3StorageDriverSettings(StorageDriverSettings):
     aws_kms_key_id: Optional[str] = pydantic.Field(
         None, validation_alias=pydantic.AliasChoices("aws_kms_key_id", "AWS_KMS_KEY_ID")
     )
-    model_config = pydantic.ConfigDict(extra="forbid")
+    model_config = pydantic.ConfigDict(extra="ignore")
 
 
 class S3StorageDriver(StorageDriver):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,5 +1,11 @@
 import pydantic
+import pytest
 
+from modelkit.assets.drivers.abc import StorageDriverSettings
+from modelkit.assets.drivers.azure import AzureStorageDriverSettings
+from modelkit.assets.drivers.gcs import GCSStorageDriverSettings
+from modelkit.assets.drivers.local import LocalStorageDriverSettings
+from modelkit.assets.drivers.s3 import S3StorageDriverSettings
 from modelkit.core.settings import ModelkitSettings
 
 
@@ -22,3 +28,23 @@ def test_modelkit_settings_working(monkeypatch):
     # because both `enable` and `SERVING_ENABLE` are set and passed to the
     # constructor.
     assert ServingSettings(enable=False).enable is False
+
+
+@pytest.mark.parametrize(
+    "Settings",
+    [
+        StorageDriverSettings,
+        GCSStorageDriverSettings,
+        AzureStorageDriverSettings,
+        S3StorageDriverSettings,
+        LocalStorageDriverSettings,
+    ],
+)
+def test_storage_driver_settings(Settings, monkeypatch):
+    monkeypatch.setenv("MODELKIT_STORAGE_BUCKET", "foo")
+    assert Settings().bucket == "foo"
+    assert Settings(bucket="bar").bucket == "bar"
+    monkeypatch.delenv("MODELKIT_STORAGE_BUCKET")
+    assert Settings(bucket="bar").bucket == "bar"
+    with pytest.raises(pydantic.ValidationError):
+        _ = Settings()


### PR DESCRIPTION
Hi 👋 

Small PR to ease extras of Storage Settings so that to allow settings overriding:
```
    monkeypatch.setenv("MODELKIT_STORAGE_BUCKET", "foo")
    assert Settings().bucket == "foo"
    assert Settings(bucket="bar").bucket == "bar"
```
Thanks!